### PR TITLE
added dsLog function for logging levels

### DIFF
--- a/src/config/config.php
+++ b/src/config/config.php
@@ -88,9 +88,10 @@ $cfg['system_version'] = '4.1.1';
 
 // This framework was developed and tested on MySQL, although since it uses
 // PHP PDO, theoretically other database types should work.
-// YMMV with other database deployments such as MSSQL, PostgreSQL, etc
+// 2016-07-25 - Have tested MSSQL using ODBC
+// YMMV with other database deployments such as Oracle, PostgreSQL, etc
 
-// PDO database type (Tested: 'mysql')
+// PDO database type (Tested: 'mysql' and mssql via 'odbc')
 $cfg['db_type'] = 'mysql';
 
 // The host address of the database
@@ -105,9 +106,16 @@ $cfg['db_user'] = 'username';
 // Database password
 $cfg['db_pass'] = 'password';
 
+//ODBC Name
+$cfg['odbc_name'] = 'ODBC_Name';
+
 // Database DSN
-$cfg['db_dsn'] = $cfg['db_type'] . ":host=" . $cfg['db_host'] . ";dbname=" .
-                 $cfg['db_name'];
+if ($cfg['db_type'] == 'mysql') {
+    $cfg['db_dsn'] = $cfg['db_type'] . ":host=" . $cfg['db_host'] . ";dbname=" .
+        $cfg['db_name'];
+} elseif ($cfg['db_type'] == 'odbc') {
+    $cfg['db_dsn'] = $cfg['db_type'] . ":" . $cfg['odbc_name'];
+}
 
 // +-------------------------------------------------------------------------+
 // |  Regional Settings                                                      |

--- a/src/server/lib/ds.class.php
+++ b/src/server/lib/ds.class.php
@@ -256,6 +256,27 @@ class ds {
     }
 
     /**
+     * Hard file logging
+     *
+     * Note: Make sure that the php user can write to the log directory
+     * Note: $error_level is a string, but standards say we should use DEBUG, INFO, WARNING, ERROR, CRITICAL.
+     *
+     * @param $error_level
+     * @param $log_message
+     */
+    public function dsLog($error_level, $log_message) {
+
+        // Log the error
+        file_put_contents(
+            $this->cfg['log_dir'],
+            "[DYNAMIC SUITE {$error_level}] {$_SERVER['REMOTE_ADDR']} " . date('Y-m-d H:i:s') .
+            " | " . $log_message  . PHP_EOL,
+            FILE_APPEND
+        );
+
+    }
+
+    /**
      * Generic SQL query function
      *
      * All data is returned as an associative array


### PR DESCRIPTION
Added a new function called dsLog, it is almost identical to dsError which this is meant to replace. It simply adds a string for standard error levels instead of using ERROR all the time. Noted in the comments that we should use the standards DEBUG, INFO, WARNING, ERROR, CRITICAL. I only added this for my own sanity, rather than relying on the message to determine level, it's in the "header".

Modified config.php to allow for dynamic switching between odbc and mysql drivers. I've personally tested MSSQL access using the ODBC driver on CentOS 7 with this configuration.